### PR TITLE
Add namespace to deploy handler

### DIFF
--- a/lib/graphql/subscription/runningPods.graphql
+++ b/lib/graphql/subscription/runningPods.graphql
@@ -1,6 +1,7 @@
 subscription runningPods {
   K8Pod {
     environment
+    namespace
     containers(state: "running") @required {
       imageName
       state

--- a/lib/machine/events/HandleRunningPods.ts
+++ b/lib/machine/events/HandleRunningPods.ts
@@ -48,14 +48,14 @@ export function handleRuningPods(): OnEvent<RunningPods.Subscription, NoParamete
         let deployGoal;
         let desc;
 
-        if (pod.environment === "staging") {
+        if (pod.environment === "gke-int-production" && pod.namespace === "api-staging") {
             try {
                 deployGoal = await findSdmGoalOnCommit(context, id, commit.repo.org.provider.providerId, deployToStaging);
                 desc = deployToStaging.successDescription;
             } catch (err) {
                 logger.info(`No goal staging deploy goal found`);
             }
-        } else if (pod.environment === "prod") {
+        } else if (pod.environment === "prod" || (pod.environment === "gke-int-production" && pod.namespace === "api")) {
             try {
                 deployGoal = await findSdmGoalOnCommit(context, id, commit.repo.org.provider.providerId, deployToProd);
                 desc = deployToProd.successDescription;


### PR DESCRIPTION
This is so that the pod deploy handler correctly detects our new GKE deployments.