### PR TITLE
Attempt at running integration tests in a goal

### DIFF
--- a/lib/machine/goals.ts
+++ b/lib/machine/goals.ts
@@ -81,17 +81,14 @@ export const deployToStaging = new GoalWithFulfillment({
 });
 
 export const integrationTest = new GoalWithFulfillment({
-    uniqueName: "IntegrationTest",
+    uniqueName: "integrationTest",
     environment: StagingEnvironment,
-    orderedName: "6-integration-test",
-    displayName: "integration test",
-    workingDescription: "Running integration tests...",
+    orderedName: "6-integration-tests",
+    displayName: "integration tests",
+    workingDescription: "Integration tests running ...",
     completedDescription: "Integration tests passed",
     failedDescription: "Integration tests failed",
-    waitingForApprovalDescription: "Promote to `prod`",
-    approvalRequired: true,
     retryFeasible: true,
-    isolated: true,
 });
 
 export const updateProdK8Specs = new GoalWithFulfillment({
@@ -185,6 +182,7 @@ export const leinServiceCancel = new Cancel({
         dockerBuild,
         updateStagingK8Specs,
         deployToStaging,
+        integrationTest,
         updateProdK8Specs,
         deployToProd],
 });
@@ -196,6 +194,14 @@ export const LeinDefaultBranchDockerGoals: Goals = goals("Lein Docker Build")
     .plan(updateStagingK8Specs).after(tag)
     .plan(deployToStaging).after(updateStagingK8Specs)
     .plan(updateProdK8Specs).after(deployToStaging)
+    .plan(deployToProd).after(updateProdK8Specs);
+
+export const LeinDefaultBranchIntegrationTestDockerGoals: Goals = goals("Lein Docker Build with Integration Test")
+    .plan(leinServiceCancel, DefaultBranchGoals, LeinDockerGoals)
+    .plan(updateStagingK8Specs).after(tag)
+    .plan(deployToStaging).after(updateStagingK8Specs)
+    .plan(integrationTest).after(deployToStaging)
+    .plan(updateProdK8Specs).after(integrationTest)
     .plan(deployToProd).after(updateProdK8Specs);
 
 export const LeinAndNodeDockerGoals: Goals = goals("Lein and npm combined goals")

--- a/lib/machine/integrationTests.ts
+++ b/lib/machine/integrationTests.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    GitHubRepoRef,
+    GitProject,
+    HandlerContext,
+    HandlerResult,
+    ProjectOperationCredentials,
+} from "@atomist/automation-client";
+import {
+    ExecuteGoal,
+    ExecuteGoalResult,
+    GoalInvocation,
+    SoftwareDeliveryMachineConfiguration,
+    spawnPromise,
+    ProgressLog,
+} from "@atomist/sdm";
+import { enrich } from "@atomist/sdm-pack-clojure/lib/machine/leinSupport";
+
+export async function runIntegrationTests(
+    configuration: SoftwareDeliveryMachineConfiguration,
+    credentials: ProjectOperationCredentials,
+    context: HandlerContext,
+    progressLog: ProgressLog): Promise<HandlerResult> {
+
+    return configuration.sdm.projectLoader.doWithProject({
+
+        id: GitHubRepoRef.from({owner: "atomisthq", repo: "org-service"}),
+        credentials,
+        context,
+        readOnly: true,
+
+    }, async (project: GitProject) => {
+        const spawnOptions = await enrich({}, project);
+        const result = await spawnPromise(
+            "./integration.sh", [], {
+                env: spawnOptions.env,
+                cwd: project.baseDir,
+            });
+        progressLog.write(result.stdout);
+        progressLog.write(result.stderr);
+        return {code: result.status};
+    });
+}
+
+export function goalRunIntegrationTests(): ExecuteGoal {
+    return async (rwlc: GoalInvocation): Promise<ExecuteGoalResult> => {
+        const { configuration, credentials, context, progressLog } = rwlc;
+        return runIntegrationTests(configuration, credentials, context, progressLog);
+    };
+}

--- a/lib/machine/integrationTests.ts
+++ b/lib/machine/integrationTests.ts
@@ -25,9 +25,9 @@ import {
     ExecuteGoal,
     ExecuteGoalResult,
     GoalInvocation,
+    ProgressLog,
     SoftwareDeliveryMachineConfiguration,
     spawnPromise,
-    ProgressLog,
 } from "@atomist/sdm";
 import { enrich } from "@atomist/sdm-pack-clojure/lib/machine/leinSupport";
 


### PR DESCRIPTION
We need to simplify our goals in machine.ts/goals.ts as they are getting out of hand! I've not taken on that work now, as I want to see if it works first.

We might choose enable integration tests for every service, but just for the moment it is conditional on a file in the repo existing so we can try it out on one or two repos first.