### PR TITLE
Apply policy for TypeScript version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9776,9 +9776,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
-      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw=="
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
+      "integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw=="
     },
     "uglify-js": {
       "version": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "tslint": "^5.17.0",
     "typedoc": "^0.14.2",
     "marked": "^0.6.2",
-    "typescript": "3.5.1"
+    "typescript": "^3.5.3"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
Apply policy `typescript-version::typescript-version`:

**New TypeScript Version Policy**
Policy version for TypeScript is `^3.5.3`.
Project *atomist/atomist-internal-sdm/upgrading* is currently using version `3.5.1`.

_TypeScript Version_
```TypeScript version (^3.5.3)```

---
<details>
  <summary>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-branch-delete:on-close]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:typescript-version::typescript-version=65546ea5b01bb62f7b74c5d027cb8128f7cda8d5ae207501c0666411a403612d]</code>
</details>