### PR TITLE
Apply policy for TypeScript version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9776,9 +9776,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
-      "integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw=="
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g=="
     },
     "uglify-js": {
       "version": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "tslint": "^5.17.0",
     "typedoc": "^0.14.2",
     "marked": "^0.6.2",
-    "typescript": "^3.5.3"
+    "typescript": "3.5.3"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
Apply policy `typescript-version::typescript-version`:

**New TypeScript Version Policy**
Policy version for TypeScript is `3.5.3`.
Project *atomist/atomist-internal-sdm/master* is currently using version `^3.5.3`.

_TypeScript Version_
```TypeScript version (3.5.3)```

---
<details>
  <summary>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-branch-delete:on-close]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:typescript-version::typescript-version=7a77ba0d291de4dc2ec4893c0b08287c9968f9fa36c9f9987c5bb676bf5c9189]</code>
</details>